### PR TITLE
Rename package to nylas-legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,9 @@
     <img src="https://brand.nylas.com/assets/downloads/logo_horizontal_png/Nylas-Logo-Horizontal-Blue_.png" alt="Aimeos logo" title="Aimeos" align="right" height="60" />
 </a>
 
-# Nylas Node.js SDK  
+# Nylas Node.js SDK (Legacy/API v2)
 
-[![Travis build status](https://travis-ci.org/nylas/nylas-nodejs.svg?branch=master)](https://travis-ci.org/nylas/nylas-nodejs)
-[![codecov](https://codecov.io/gh/nylas/nylas-nodejs/branch/main/graph/badge.svg?token=94IMGU4F09)](https://codecov.io/gh/nylas/nylas-nodejs)
-
-This is the GitHub repository for the Nylas Node SDK and this repo is primarily for anyone who wants to make contributions to the SDK or install it from source. If you are looking to use Node to access the Nylas Email, Calendar, or Contacts API you should refer to our official [Node SDK Quickstart Guide](https://developer.nylas.com/docs/developer-tools/sdk/node-sdk/).
-
-The Nylas Communications Platform provides REST APIs for [Email](https://developer.nylas.com/docs/connectivity/email/), [Calendar](https://developer.nylas.com/docs/connectivity/calendar/), and [Contacts](https://developer.nylas.com/docs/connectivity/contacts/), and the Node SDK is the quickest way to build your integration using JavaScript.
-
-Here are some resources to help you get started:
-
-- [Nylas SDK Tutorials](https://developer.nylas.com/docs/the-basics/tutorials/nodejs/)
-- [Quickstart](https://developer.nylas.com/docs/the-basics/quickstart/)
-- [Nylas API Reference](https://developer.nylas.com/docs/api/)
-
+This is the legacy version of the Nylas Node.js SDK, which supports the Nylas API v2. This version of the SDK is currently in maintenance mode and is supported for the purpose of assisting with migration to the new API v3. We recommend migrating and using the current [Nylas Node.js SDK](https://www.github.com/nylas/nylas-nodejs) for the latest and greatest features.
 
 ## ⚙️ Install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nylas",
+  "name": "nylas-legacy",
   "version": "6.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nylas",
+      "name": "nylas-legacy",
       "version": "6.11.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nylas",
+  "name": "nylas-legacy",
   "version": "6.11.1",
-  "description": "A NodeJS wrapper for the Nylas REST API for email, contacts, and calendar.",
+  "description": "A NodeJS wrapper for the Nylas v2 REST API for email, contacts, and calendar.",
   "main": "lib/nylas.js",
   "types": "lib/nylas.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nylas/nylas-nodejs.git"
+    "url": "https://github.com/nylas/nylas-nodejs-legacy.git"
   }
 }


### PR DESCRIPTION
This PR renames the package to nylas-legacy in npm.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.